### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,4 +1,6 @@
 name: Build
+permissions:
+  contents: read
 
 env:
   DOTNET_NOLOGO: true
@@ -74,6 +76,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     if: success() && github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
+    permissions:
+      contents: read
+      packages: write
 
     steps:
       - name: Download Artifact


### PR DESCRIPTION
Potential fix for [https://github.com/loresoft/Arbiter/security/code-scanning/1](https://github.com/loresoft/Arbiter/security/code-scanning/1)

To remediate the flagged issue, add a top-level `permissions` block to `.github/workflows/dotnet.yml` setting the minimum required permissions for the workflow. Alternatively, if jobs have differing permission needs, add a `permissions` block for each job. In this workflow:  
- The `build` job should only need permission to read repository contents and, optionally, read pull requests (if outputs/reports are involved) but *not* write access.
- The `deploy` job pushes packages to package registries; when using `${{ secrets.GITHUB_TOKEN }}` for GitHub Packages, it should grant `contents: read` (already default for push to packages) and, if needed, `packages: write`.
- Artifact upload/download does not require extra permissions if it's all local.
- The `pages` job *already* specifies its required permissions.

Best practice is to set a restrictive root-level `permissions` block (`contents: read`) and specifically broaden permissions only within jobs that require it.  
Edit `.github/workflows/dotnet.yml`:  
- Add a top-level `permissions:` block just after the `name: Build` statement, before `env:`, as `contents: read`.  
- Explicitly grant the `deploy` job the `packages: write` permission via a per-job `permissions` block.

No additional imports or dependencies are needed for this change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
